### PR TITLE
Hotfix - Unset the body param after each usage so it does not impact …

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -196,8 +196,11 @@ abstract class Client
         try {
             $response = $this->httpClient->request($this->options['method'], $this->url, $this->parameters);
         } catch (RequestException $ex) {
+            unset( $this->parameters['body'] );
             $this->assignExceptions($ex);
         }
+
+        unset( $this->parameters['body'] );
 
         $formattedResponse = $this->formatter->formatResponse($response);
 


### PR DESCRIPTION
…subsequent API calls

Because Forrest is a singleton, $this->parameters is reused over and over for each API call made. Salesforce happen to throw a "Sorry, maintenance mode" error whenever a GET request to the API contains a body. The body param must be unset between usages to prevent this error.